### PR TITLE
Bugfix: mktemp template is not complete

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-declare -r output_file="$(mktemp -t git-extensions)" || exit $?
-declare -r scratch="$(mktemp -d -t git-extensions)" || exit $?
+declare -r output_file="$(mktemp -t git-extensions-XXXXX)" || exit $?
+declare -r scratch="$(mktemp -d -t git-extensions-XXXXX)" || exit $?
 declare -r pwd=`pwd` || exit $?
 
 declare -r ignore='.gitignore_global'


### PR DESCRIPTION
I got `mktemp: too few X's in template ‘git-extensions’`, so I added some X's.
See the man page (https://www.gnu.org/software/autogen/mktemp.html), which says:
> TEMPLATE must contain at least 3 consecutive `X's in last component.