### PR TITLE
Added an alternative way of installing git-preview

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -114,10 +114,16 @@ cp -f ${scratch}/git-extensions-master/home/${ignore} ~/${ignore} || exit $?
 git config --global core.excludesfile ~/${ignore}
 echo -e "  ~/$ignore"
 
-cp -f ${scratch}/git-extensions-master/bin/git-preview /usr/local/bin/git-preview || exit $?
-chmod 777 /usr/local/bin/git-preview || exit $?
-echo -e "  git preview"
-
+if [ -w /usr/local/bin ]; then
+    cp -f ${scratch}/git-extensions-master/bin/git-preview /usr/local/bin/git-preview || exit $?
+    chmod 777 /usr/local/bin/git-preview || exit $?
+    echo -e "  git preview"
+else
+    mkdir -p $HOME/bin
+    cp -f ${scratch}/git-extensions-master/bin/git-preview $HOME/bin/git-preview || exit $?
+    chmod 700 $HOME/bin/git-preview || exit $?
+    echo -e "  git preview has been copied to ~/bin. Please make sure this directory is in your PATH."
+fi
 
 cleanup || exit $?
 


### PR DESCRIPTION
I have no rights in `/usr/local/bin` and besides that I don't even want `git-preview` to be installed globally. I added an alternative way of installing if the current user has no rights to write in `/usr/local/bin`: copy it to `~/bin`. The user has to take care though that this is in his PATH.

According to [this Stackexchange question](https://askubuntu.com/questions/402353/how-to-add-home-username-bin-to-path) it's already in the PATH in some distributions. If it's not, users can add it themselves in `~/.bashrc`:

```
# set PATH so it includes user's private bin if it exists
if [ -d "$HOME/bin" ] ; then
    PATH="$HOME/bin:$PATH"
fi
```